### PR TITLE
Fix typos in docs and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Make your docstrings excellent with a single command. It’s fast (~30s), cheap
 
 * **One‑command upgrades** – `lovethedocs update path/`
 * **Choose your style** – `NumPy` (default) or `Google` with `-s/--style`
-* **Safe by defualt** – edits live in `path/.lovethedocs/` until you accept them
+* **Safe by default** – edits live in `path/.lovethedocs/` until you accept them
 * **Parallel & fast** – set `-c/--concurrency` to speed things up
 
 ---

--- a/src/lovethedocs/cli/app.py
+++ b/src/lovethedocs/cli/app.py
@@ -132,10 +132,10 @@ def update(
             )
 
 
-review_example = (
-    "Examples\n\n"
-    "--------\n\n"
-    "lovethedocs review src/                      # open diffs for review (Cursor defualt)\n\n"
+    review_example = (
+        "Examples\n\n"
+        "--------\n\n"
+    "lovethedocs review src/                      # open diffs for review (Cursor default)\n\n"
     "lovethedocs review -v git src/               # use git as a diff viewer\n\n"
 )
 


### PR DESCRIPTION
## Summary
- correct spelling of *default* in README
- fix help text for `review` CLI command

## Testing
- `pytest -q` *(fails: command not found)*